### PR TITLE
Tentative fix of plotSpectrum.m

### DIFF
--- a/utils/plotSpectrums.m
+++ b/utils/plotSpectrums.m
@@ -9,16 +9,18 @@ function h1 = plotSpectrums(Users,Stations)
         if checkUserSchedule(Users(pp),station)
           Fs = Stations([Stations.NCellID] == Users(pp).ENodeBID).Tx.WaveformInfo.SamplingRate;
           sig = setPower(Users(pp).Rx.Waveform,Users(pp).Rx.RxPwdBm);
-          F = fft(sig)./length(sig);
-          Fpsd = 10*log10(fftshift(abs(F).^2))+30;
-          nfft=length(sig);
-          f=Fs/2*[-1:2/nfft:1-2/nfft];
-          plot(f,Fpsd);
-          title(['User: ',num2str(pp)],'Fontsize',8);
-          ylabel('dBm');
-          xlabel('Hz');
-          ylim([min(Fpsd) max(Fpsd)])
-          set(hs(pp),'FontSize',8);
+          if(~isempty(sig))
+              F = fft(sig)./length(sig);
+              Fpsd = 10*log10(fftshift(abs(F).^2))+30;
+              nfft=length(sig);
+              f=Fs/2*[-1:2/nfft:1-2/nfft];
+              plot(f,Fpsd);
+              title(['User: ',num2str(pp)],'Fontsize',8);
+              ylabel('dBm');
+              xlabel('Hz');
+              ylim([min(Fpsd) max(Fpsd)])
+              set(hs(pp),'FontSize',8);
+          end
         end
         
 


### PR DESCRIPTION
Hi,
I get an error when the plotting is enabled with the "draw" boolean in the config file, at the iteration 47 of the main script (with nothing changed with respect to the latest commit in the master).
The error happens because plotSpectrums is trying to plot an empty vector.

```
Error using ylim (line 31)
Limits must be a 2-element vector of increasing numeric values.

Error in plotSpectrums (line 20)
          ylim([min(Fpsd) max(Fpsd)])

Error in simulate (line 250)
		[hSpectrums(1)] = plotSpectrums(Users,Stations);

Error in main (line 72)
		simulate(Param, simData, utilLo(iUtilLo), utilHi(iUtilHi));
```

This is a tentative fix, but I don't know if there are other elements to consider. 
Best,
Michele